### PR TITLE
dispose() of undefined

### DIFF
--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -38,7 +38,7 @@ class CompositeDisposable
     unless @disposed
       @disposed = true
       @disposables.forEach (disposable) ->
-        disposable.dispose()
+        disposable.dispose() if disposable?
       @disposables = null
     return
 


### PR DESCRIPTION
Because Set.prototype.forEach() can returns undefined,

see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach,

and this issue: https://github.com/richrace/highlight-selected/issues/67.