### PR TITLE
Add `CompositeDisposable::addIfDisposable`

### DIFF
--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -30,7 +30,7 @@ describe "CompositeDisposable", ->
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
 
-  it "denies to add an object that does not respond to ::dispose", ->
+  it "throws an error if a disposable does not implement ::dispose", ->
     composite = new CompositeDisposable
 
     expect(-> composite.add(undefined)).toThrow()

--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -30,9 +30,18 @@ describe "CompositeDisposable", ->
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
 
-  it "throws an error if a disposable does not implement ::dispose", ->
+  it "throws an error when adding a disposable without a ::dispose function", ->
     composite = new CompositeDisposable
 
-    expect(-> composite.add(undefined)).toThrow()
-    expect(-> composite.add(null)).toThrow()
-    expect(-> composite.add(whatever: ->)).toThrow()
+    expect(-> composite.add(undefined)).toThrow("undefined must implement ::dispose!")
+    expect(-> composite.add(null)).toThrow("null must implement ::dispose!")
+    expect(-> composite.add(whatever: ->)).toThrow("[object Object] must implement ::dispose!")
+
+  it "throws an error when disposing a disposable without a ::dispose function", ->
+    composite = new CompositeDisposable
+    disposable = {dispose: ->}
+    composite.add(disposable)
+
+    delete disposable["dispose"]
+
+    expect(-> composite.dispose()).toThrow("[object Object] must implement ::dispose!")

--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -30,7 +30,7 @@ describe "CompositeDisposable", ->
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
 
-  describe "::addIfDisposable(args...)", ->
+  describe "::addIfDisposable(disposables...)", ->
     it "ignores disposables without a ::dispose function", ->
       composite = new CompositeDisposable
       composite.addIfDisposable(disposable1, undefined, null)

--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -30,18 +30,12 @@ describe "CompositeDisposable", ->
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
 
-  it "throws an error when adding a disposable without a ::dispose function", ->
-    composite = new CompositeDisposable
+  describe "::addIfDisposable(args...)", ->
+    it "ignores disposables without a ::dispose function", ->
+      composite = new CompositeDisposable
+      composite.addIfDisposable(disposable1, undefined, null)
+      composite.addIfDisposable(whatever: ->)
 
-    expect(-> composite.add(undefined)).toThrow("undefined must implement ::dispose!")
-    expect(-> composite.add(null)).toThrow("null must implement ::dispose!")
-    expect(-> composite.add(whatever: ->)).toThrow("[object Object] must implement ::dispose!")
+      composite.dispose()
 
-  it "throws an error when disposing a disposable without a ::dispose function", ->
-    composite = new CompositeDisposable
-    disposable = {dispose: ->}
-    composite.add(disposable)
-
-    delete disposable["dispose"]
-
-    expect(-> composite.dispose()).toThrow("[object Object] must implement ::dispose!")
+      expect(disposable1.disposed).toBe true

--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -29,3 +29,10 @@ describe "CompositeDisposable", ->
     expect(disposable1.disposed).toBe true
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
+
+  it "denies to add an object that does not respond to ::dispose", ->
+    composite = new CompositeDisposable
+
+    expect(-> composite.add(undefined)).toThrow()
+    expect(-> composite.add(null)).toThrow()
+    expect(-> composite.add(whatever: ->)).toThrow()

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -37,7 +37,7 @@ class CompositeDisposable
   dispose: ->
     unless @disposed
       @disposed = true
-      @disposables.forEach (disposable) =>
+      @disposables.forEach (disposable) ->
         disposable.dispose()
       @disposables = null
     return

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -54,7 +54,11 @@ class CompositeDisposable
   #   method.
   add: ->
     unless @disposed
-      @disposables.add(disposable) for disposable in arguments
+      for disposable in arguments
+        if typeof disposable?.dispose isnt "function"
+          throw new Error("#{disposable} must implement ::dispose!")
+
+        @disposables.add(disposable)
     return
 
   # Public: Remove a previously added disposable.

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -58,7 +58,7 @@ class CompositeDisposable
     return
 
   # Public: Add a disposable to be disposed when the composite is disposed,
-  # ignoring those ones that do not implement `.dispose()`.
+  # ignoring it if it does not implement `.dispose()`.
   #
   # See {CompositeDisposable::add} documentation for further information.
   #

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -57,10 +57,16 @@ class CompositeDisposable
       @disposables.add(disposable) for disposable in arguments
     return
 
+  # Public: Add a disposable to be disposed when the composite is disposed,
+  # ignoring those ones that do not implement `.dispose()`.
+  #
+  # See {CompositeDisposable::add} documentation for further information.
+  #
+  # * `disposable` {Disposable} instance or any object with a `.dispose()`
+  #   method.
   addIfDisposable: ->
-    unless @disposed
-      for disposable in arguments when typeof disposable?.dispose is "function"
-        @disposables.add(disposable)
+    for disposable in arguments
+      @add(disposable) if typeof disposable?.dispose is "function"
     return
 
   # Public: Remove a previously added disposable.

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -38,7 +38,6 @@ class CompositeDisposable
     unless @disposed
       @disposed = true
       @disposables.forEach (disposable) =>
-        @ensureDisposable(disposable)
         disposable.dispose()
       @disposables = null
     return
@@ -55,8 +54,12 @@ class CompositeDisposable
   #   method.
   add: ->
     unless @disposed
-      for disposable in arguments
-        @ensureDisposable(disposable)
+      @disposables.add(disposable) for disposable in arguments
+    return
+
+  addIfDisposable: ->
+    unless @disposed
+      for disposable in arguments when typeof disposable?.dispose is "function"
         @disposables.add(disposable)
     return
 
@@ -73,9 +76,3 @@ class CompositeDisposable
   clear: ->
     @disposables.clear() unless @disposed
     return
-
-  # Private: Ensures that the given `disposable` responds to ::dispose and
-  # throws an error if it doesn't.
-  ensureDisposable: (disposable) ->
-    if typeof disposable?.dispose isnt "function"
-      throw new Error("#{disposable} must implement ::dispose!")

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -37,7 +37,8 @@ class CompositeDisposable
   dispose: ->
     unless @disposed
       @disposed = true
-      @disposables.forEach (disposable) ->
+      @disposables.forEach (disposable) =>
+        @ensureDisposable(disposable)
         disposable.dispose()
       @disposables = null
     return
@@ -55,9 +56,7 @@ class CompositeDisposable
   add: ->
     unless @disposed
       for disposable in arguments
-        if typeof disposable?.dispose isnt "function"
-          throw new Error("#{disposable} must implement ::dispose!")
-
+        @ensureDisposable(disposable)
         @disposables.add(disposable)
     return
 
@@ -74,3 +73,9 @@ class CompositeDisposable
   clear: ->
     @disposables.clear() unless @disposed
     return
+
+  # Private: Ensures that the given `disposable` responds to ::dispose and
+  # throws an error if it doesn't.
+  ensureDisposable: (disposable) ->
+    if typeof disposable?.dispose isnt "function"
+      throw new Error("#{disposable} must implement ::dispose!")


### PR DESCRIPTION
~~This should allow package developers to catch issues like https://github.com/atom/tabs/issues/183 early on.~~

This method will allow to have less strict checks whenever we add a disposable for code that we do not manage, thereby avoiding issues like https://github.com/atom/tabs/issues/183 altogether.

/cc: @kevinsawicki @benogle 