### PR TITLE
Add `Disposable.isDisposable`

### DIFF
--- a/spec/disposable-spec.coffee
+++ b/spec/disposable-spec.coffee
@@ -21,7 +21,7 @@ describe "Disposable", ->
     disposable.dispose()
     expect(disposalAction.callCount).toBe 1
 
-  describe "::isDisposable(object)", ->
+  describe ".isDisposable(object)", ->
     it "returns true if the object implements the ::dispose function", ->
       expect(Disposable.isDisposable(new Disposable(->))).toBe(true)
       expect(Disposable.isDisposable({dispose: ->})).toBe(true)

--- a/spec/disposable-spec.coffee
+++ b/spec/disposable-spec.coffee
@@ -20,3 +20,13 @@ describe "Disposable", ->
 
     disposable.dispose()
     expect(disposalAction.callCount).toBe 1
+
+  describe "::isDisposable(object)", ->
+    it "returns true if the object implements the ::dispose function", ->
+      expect(Disposable.isDisposable(new Disposable(->))).toBe(true)
+      expect(Disposable.isDisposable({dispose: ->})).toBe(true)
+
+      expect(Disposable.isDisposable(null)).toBe(false)
+      expect(Disposable.isDisposable(undefined)).toBe(false)
+      expect(Disposable.isDisposable({foo: ->})).toBe(false)
+      expect(Disposable.isDisposable({dispose: 1})).toBe(false)

--- a/src/disposable.coffee
+++ b/src/disposable.coffee
@@ -6,6 +6,15 @@ module.exports =
 class Disposable
   disposed: false
 
+  # Public: Ensure that an `object` correctly implements the `Disposable`
+  # contract.
+  #
+  # * `object` Any object you want to perform the check against.
+  #
+  # Returns a {Boolean} indicating whether `object` is a valid `Disposable`.
+  @isDisposable: (object) ->
+    typeof object?.dispose is "function"
+
   ###
   Section: Construction and Destruction
   ###


### PR DESCRIPTION
So that we can check whether an object correctly implements the `Disposable` contract, as discussed in #12.

/cc: @maxbrunsfeld @nathansobo @kevinsawicki 