### PR TITLE
Bump to version 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-kit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Simple library for implementing and consuming evented APIs",
   "main": "./lib/event-kit",
   "scripts": {


### PR DESCRIPTION
I bumped the minor version, as this was a backward compatible change but not a bug fix.

After we :ship: this, we need to publish the corresponding package on npm as well, so that we can upgrade it on Atom core and, finally, address https://github.com/atom/tabs/issues/183.

Thanks!

/cc: @maxbrunsfeld @kevinsawicki @nathansobo 