### PR TITLE
Feature: Add DOMEventListener class

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ subscriptions.add user2.onDidChangeName (name) -> console.log("User 2: #{name}")
 subscriptions.dispose()
 ```
 
+## Working with DOM Events
+
+Event kit provides the `DOMEventListener` class to integrate with the DOM Event
+API. `DOMEventListener` instances are disposables that will remove the event
+listener on disposal.
+
+```coffee
+{DOMEventListener} = require 'event-kit'
+
+subscription = new DOMEventListener document.body, 'click', ->
+  console.log 'body was clicked'
+,
+  # initiate capture for this event
+  useCapture: true
+  # delegate event to elements that match the delegationTarget selector
+  delegationTarget: '.delegation-target'
+  # immediately dispose of the event listener when it is triggered for the first time
+  once: true
+```
+
 ## Creating Your Own Disposables
 
 Disposables are convenient ways to represent a resource you will no longer

--- a/spec/dom-event-listener-spec.coffee
+++ b/spec/dom-event-listener-spec.coffee
@@ -11,6 +11,15 @@ describe "DOMEventListener", ->
     listener?.dispose?()
     counter = 0
 
+  it "should throw a TypeError when the provided target is not an instance of EventTarget", ->
+    error = null
+    try
+      listener = new DOMEventListener {}, 'click', ->
+        counter++
+    catch e
+      error = e
+    expect(error instanceof TypeError).toBeTruthy()
+
   describe "when no options are provided", ->
     beforeEach ->
       listener = new DOMEventListener document.body, 'click', ->

--- a/spec/dom-event-listener-spec.coffee
+++ b/spec/dom-event-listener-spec.coffee
@@ -1,4 +1,4 @@
-window.DEL = DOMEventListener = require '../src/dom-event-listener'
+DOMEventListener = require '../src/dom-event-listener'
 
 dispatchEvent = (target=document.body) ->
   target.dispatchEvent new MouseEvent 'click', {bubbles: true}

--- a/spec/dom-event-listener-spec.coffee
+++ b/spec/dom-event-listener-spec.coffee
@@ -1,0 +1,53 @@
+window.DEL = DOMEventListener = require '../src/dom-event-listener'
+
+dispatchEvent = (target=document.body) ->
+  target.dispatchEvent new MouseEvent 'click', {bubbles: true}
+
+describe "DOMEventListener", ->
+  listener = null
+  counter = 0
+
+  beforeEach ->
+    listener?.dispose?()
+    counter = 0
+
+  describe "when no options are provided", ->
+    beforeEach ->
+      listener = new DOMEventListener document.body, 'click', ->
+        counter++
+
+    it "registers an event listener with a DOM element", ->
+      dispatchEvent()
+      expect(counter).toEqual(1)
+
+    it "removes the event listener when the dispose method is called", ->
+      listener.dispose()
+      dispatchEvent()
+      expect(counter).toEqual(0)
+
+  describe "when the once option is enabled", ->
+    beforeEach ->
+      listener = new DOMEventListener document.body, 'click', ->
+        counter++
+      , once: true
+
+    it "will dispose itself the first time the event is triggered", ->
+      dispatchEvent()
+      dispatchEvent()
+      expect(counter).toEqual(1)
+
+  describe "when a delegationTarget is provided", ->
+    delegationTarget = null
+
+    beforeEach ->
+      delegationTarget = document.createElement('div')
+      delegationTarget.classList.add('delegation-target')
+      document.body.appendChild(delegationTarget)
+      window.listener = listener = new DOMEventListener document.body, 'click', ->
+        counter++
+      , delegationTarget: '.delegation-target'
+
+    it "should call the callback only when the event is triggered on the delegation target", ->
+      dispatchEvent()
+      dispatchEvent(delegationTarget)
+      expect(counter).toEqual(1)

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -7,10 +7,8 @@ module.exports = class DOMEventListener extends Disposable
 
     wrapper = (event) =>
       if delegationTarget
-        {target} = event
-        while !target.matches(delegationTarget) && target != el
-          target = target.parentNode
-        if target != el
+        target = event.target.closest(delegationTarget)
+        if el.contains target
           @dispose() if once
           cb.call(target, event)
       else

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -2,6 +2,9 @@ Disposable = require './disposable'
 
 module.exports = class DOMEventListener
   constructor: (el, type, cb, {useCapture, delegationTarget, once}={}) ->
+    unless el instanceof EventTarget
+      throw new TypeError('Failed to create DOMEventListener: parameter 1 is not of type EventTarget')
+
     wrapper = (event) =>
       @dispose() if once
       if delegationTarget

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -6,14 +6,15 @@ module.exports = class DOMEventListener
       throw new TypeError('Failed to create DOMEventListener: parameter 1 is not of type EventTarget')
 
     wrapper = (event) =>
-      @dispose() if once
       if delegationTarget
         {target} = event
         while !target.matches(delegationTarget) && target != el
           target = target.parentNode
         if target != el
+          @dispose() if once
           cb.call(target, event)
       else
+        @dispose() if once
         cb.call(el, event)
 
     el.addEventListener(type, wrapper, useCapture)

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -1,6 +1,6 @@
 Disposable = require './disposable'
 
-module.exports = class DOMEventListener
+module.exports = class DOMEventListener extends Disposable
   constructor: (el, type, cb, {useCapture, delegationTarget, once}={}) ->
     unless el instanceof EventTarget
       throw new TypeError('Failed to create DOMEventListener: parameter 1 is not of type EventTarget')
@@ -18,9 +18,5 @@ module.exports = class DOMEventListener
         cb.call(el, event)
 
     el.addEventListener(type, wrapper, useCapture)
-    @disposable = new Disposable ->
+    super ->
       el.removeEventListener(type, wrapper, useCapture)
-
-  dispose: ->
-    @disposable.dispose()
-    return

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -1,0 +1,20 @@
+module.exports = class DOMEventListener
+  constructor: (el, type, cb, {useCapture, delegationTarget, once}) ->
+    wrapper = (event) =>
+      @dispose() if once
+      if delegationTarget
+        {target} = event
+        while !target.matches(delegationTarget) && target != el
+          target = target.parentNode
+        if target != el
+          cb.call(target, event)
+      else
+        cb.call(el, event)
+
+    el.addEventListener(type, wrapper, useCapture)
+    @disposable = new Disposable ->
+      el.removeEventListener(type, wrapper, useCapture)
+
+  dispose: ->
+    @disposable.dispose()
+    return

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -1,7 +1,7 @@
 Disposable = require './disposable'
 
 module.exports = class DOMEventListener
-  constructor: (el, type, cb, {useCapture, delegationTarget, once}) ->
+  constructor: (el, type, cb, {useCapture, delegationTarget, once}={}) ->
     wrapper = (event) =>
       @dispose() if once
       if delegationTarget

--- a/src/dom-event-listener.coffee
+++ b/src/dom-event-listener.coffee
@@ -1,3 +1,5 @@
+Disposable = require './disposable'
+
 module.exports = class DOMEventListener
   constructor: (el, type, cb, {useCapture, delegationTarget, once}) ->
     wrapper = (event) =>

--- a/src/event-kit.coffee
+++ b/src/event-kit.coffee
@@ -1,3 +1,4 @@
 exports.Emitter = require './emitter'
 exports.Disposable = require './disposable'
 exports.CompositeDisposable = require './composite-disposable'
+exports.DOMEventListener = require './dom-event-listener'


### PR DESCRIPTION
I love the disposables mechanism, but there is no integration with the DOM event API. This PR aims to fix that with the `DOMEventListener` class. A `DOMEventListener` is a disposable object that registers an event listener in its constructor and removes it when it is disposed.

The constructor's signature is `new DOMEventListener((EventTarget) target, (string) eventType, (func) callback, {(bool) useCapture, (string) delegationTarget, (bool) once})`. The constructor will throw a `TypeError` when `!(target instanceof EventTarget)`.

The last parameter object is entirely optional.

Set `useCapture` to true to initiate the event in the capture phase.

When a `delegationTarget` is provided in the options, the callback will only be called if the event's target is (a child of) an element that matches the `delegationTarget` string.

When `once` is truthy, the event listener will be disposed as soon as it is called for the first time.

Example:
```coffee
{DOMEventListener} = require 'event-kit'

subscription = new DOMEventListener document.body, 'click', ->
  console.log 'body clicked'

# later when not needed anymore
subscription.dispose()
```