### PR TITLE
:fire: Remove deprecated 'off' and grim

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
       "url": "http://github.com/atom/event-kit/raw/master/LICENSE.md"
     }
   ],
-  "dependencies": {
-    "grim": "^1.2.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "coffee-cache": "^0.2.0",
     "coffee-script": "^1.7.0",

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -1,2 +1,1 @@
 require 'coffee-cache'
-require('grim').includeDeprecatedAPIs = false

--- a/src/disposable.coffee
+++ b/src/disposable.coffee
@@ -1,5 +1,3 @@
-Grim = require 'grim'
-
 # Essential: A handle to a resource that can be disposed. For example,
 # {Emitter::on} returns disposables representing subscriptions.
 module.exports =
@@ -36,8 +34,3 @@ class Disposable
       @disposalAction?()
       @disposalAction = null
     return
-
-if Grim.includeDeprecatedAPIs
-  Disposable::off = ->
-    Grim.deprecate("Use ::dispose to cancel subscriptions instead of ::off")
-    @dispose()


### PR DESCRIPTION
This is an old api from the 0.x days, and grim is bloating up this library.