### PR TITLE
Enable recovery from errors thrown by handlers.

### DIFF
--- a/spec/emitter-spec.coffee
+++ b/spec/emitter-spec.coffee
@@ -1,6 +1,7 @@
 Emitter = require '../src/emitter'
 
 describe "Emitter", ->
+
   it "invokes the observer when the named event is emitted until disposed", ->
     emitter = new Emitter
 
@@ -43,3 +44,87 @@ describe "Emitter", ->
     emitter.emit 'foo', 1
     emitter.emit 'foo', 2
     expect(events).toEqual []
+
+  it "Does throw when an observer throws and no ensureHandlerInvoke", ->
+    emitter = new Emitter
+    hadThrow = false
+
+    sub = emitter.on 'bar', (value) -> throw new Error()
+    try
+      emitter.emit 'bar', 1
+    catch error
+      hadThrow = true
+    sub.dispose()
+
+    expect(hadThrow).toBe true
+
+  it "isEnsureHandlerInvoke", ->
+    expect(Emitter.isEnsureHandlerInvoke()).toBe(false)
+    Emitter.setEnsureHandlerInvoke(true)
+    expect(Emitter.isEnsureHandlerInvoke()).toBe(true)
+    Emitter.setEnsureHandlerInvoke(false)
+    expect(Emitter.isEnsureHandlerInvoke()).toBe(false)
+
+  it "Does not throw when an observer throws and ensureHandlerInvoke", ->
+    Emitter.setEnsureHandlerInvoke(true)
+    emitter = new Emitter
+    hadThrow = false
+
+    sub = emitter.on 'bar', (value) -> throw new Error()
+    try
+      emitter.emit 'bar', 1
+    catch error
+      hadThrow = true
+    sub.dispose()
+
+    expect(hadThrow).toBe false
+    Emitter.setEnsureHandlerInvoke(false)
+
+  it "Invokes onHandlerException when a handler throws", ->
+    emitter = new Emitter
+    hadUncaughtException = false
+
+    Emitter.setEnsureHandlerInvoke(true)
+    uncaughtException = (error) -> hadUncaughtException = true
+    subUncaught = Emitter.onHandlerException(uncaughtException)
+
+    sub = emitter.on 'bar', (value) -> throw new Error()
+    emitter.emit 'bar', 1
+
+    sub.dispose()
+    subUncaught.dispose()
+    Emitter.setEnsureHandlerInvoke(false)
+    expect(hadUncaughtException).toBe true
+
+  it "invokes all observers even when one observer throws", ->
+    emitter = new Emitter
+    barEvents = []
+
+    Emitter.setEnsureHandlerInvoke(true)
+    sub1 = emitter.on 'bar', (value) -> barEvents.push(value)
+    sub2 = emitter.on 'bar', (value) -> throw new Error()
+    sub3 = emitter.on 'bar', (value) -> barEvents.push(value * value)
+
+    emitter.emit 'bar', 1
+    emitter.emit 'bar', 2
+    emitter.emit 'bar', 3
+
+    sub1.dispose()
+    sub2.dispose()
+    sub3.dispose()
+    Emitter.setEnsureHandlerInvoke(false)
+
+    expect(barEvents).toEqual [1, 1, 2, 4, 3, 9]
+
+  it "throw from uncaughtHandler handler terminates", ->
+    Emitter.setEnsureHandlerInvoke(true)
+    uncaughtException = (value) -> throw new Error()
+    subUncaught = Emitter.onHandlerException(uncaughtException)
+
+    emitter = new Emitter
+    sub = emitter.on 'bar', (value) -> throw new Error()
+    emitter.emit 'bar', 1
+
+    sub.dispose()
+    subUncaught.dispose()
+    Emitter.setEnsureHandlerInvoke(false)


### PR DESCRIPTION
Currently, when a handler throws, any remaining handlers for the event
are not called. In Atom, when buggy packages throw the remaining
packages do not get called, and typically the default processing
also stops. As a result a buggy package can cause other well behaved
packages to stop working correctly.

This is particularly troublesome when a handler for TextBuffer
will-save throws as this prevents the user from being able to save
their file.

With this change, when a handler throws, process uncaughtException is
emitted. If process uncaughtException had any handlers, then the
exception is considered handled and any remaining handlers are invoked.
If process uncaughtException has no handlers then the thrown exception
is rethrown for maximum backwards compatibility.

Emitting process uncaughtException enables detecting and debugging
buggy handlers.

This is related to https://github.com/atom/atom/issues/10091