### PR TITLE
Allow emitters' listeners to be inspected

### DIFF
--- a/spec/emitter-spec.coffee
+++ b/spec/emitter-spec.coffee
@@ -44,6 +44,42 @@ describe "Emitter", ->
     emitter.emit 'foo', 2
     expect(events).toEqual []
 
+  it "allows the listeners to be inspected", ->
+    emitter = new Emitter
+
+    disposable1 = emitter.on 'foo', ->
+    expect(emitter.getEventNames()).toEqual ['foo']
+    expect(emitter.listenerCountForEventName('foo')).toBe(1)
+    expect(emitter.listenerCountForEventName('bar')).toBe(0)
+    expect(emitter.getTotalListenerCount()).toBe(1)
+
+    disposable2 = emitter.on 'bar', ->
+    expect(emitter.getEventNames()).toEqual ['foo', 'bar']
+    expect(emitter.listenerCountForEventName('foo')).toBe(1)
+    expect(emitter.listenerCountForEventName('bar')).toBe(1)
+    expect(emitter.getTotalListenerCount()).toBe(2)
+
+    emitter.preempt 'foo', ->
+    expect(emitter.getEventNames()).toEqual ['foo', 'bar']
+    expect(emitter.listenerCountForEventName('foo')).toBe(2)
+    expect(emitter.listenerCountForEventName('bar')).toBe(1)
+    expect(emitter.getTotalListenerCount()).toBe(3)
+
+    disposable1.dispose()
+    expect(emitter.getEventNames()).toEqual ['foo', 'bar']
+    expect(emitter.listenerCountForEventName('foo')).toBe(1)
+    expect(emitter.listenerCountForEventName('bar')).toBe(1)
+    expect(emitter.getTotalListenerCount()).toBe(2)
+
+    disposable2.dispose()
+    expect(emitter.getEventNames()).toEqual ['foo']
+    expect(emitter.listenerCountForEventName('foo')).toBe(1)
+    expect(emitter.listenerCountForEventName('bar')).toBe(0)
+    expect(emitter.getTotalListenerCount()).toBe(1)
+
+    emitter.clear()
+    expect(emitter.getTotalListenerCount()).toBe(0)
+
   describe "when a handler throws an exception", ->
     describe "when no exception handlers are registered on Emitter", ->
       it "throws exceptions as normal, stopping subsequent handlers from firing", ->

--- a/src/emitter.coffee
+++ b/src/emitter.coffee
@@ -129,7 +129,10 @@ class Emitter
       newHandlers = []
       for handler in oldHandlers when handler isnt handlerToRemove
         newHandlers.push(handler)
-      @handlersByEventName[eventName] = newHandlers
+      if newHandlers.length > 0
+        @handlersByEventName[eventName] = newHandlers
+      else
+        delete @handlersByEventName[eventName]
     return
 
   ###
@@ -146,3 +149,15 @@ class Emitter
       for handler in handlers
         @constructor.dispatch(handler, value)
     return
+
+  getEventNames: ->
+    Object.keys(@handlersByEventName)
+
+  listenerCountForEventName: (eventName) ->
+    @handlersByEventName[eventName]?.length ? 0
+
+  getTotalListenerCount: ->
+    result = 0
+    for eventName in Object.keys(@handlersByEventName)
+      result += @handlersByEventName[eventName].length
+    result


### PR DESCRIPTION
The API is based loosely on node's [`EventEmitter` API](https://nodejs.org/api/events.html#events_emitter_eventnames), but atom-ified.