### PR TITLE
Allow Objects With A destroy() Function To Be Added To CompositeDisposable

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "coffee-cache": "^0.2.0",
-    "coffee-script": "^1.7.0",
-    "grunt": "^0.4.1",
-    "grunt-atomdoc": "^1.0.0",
-    "grunt-cli": "^0.1.8",
-    "grunt-coffeelint": "^0.0.6",
-    "grunt-contrib-coffee": "^0.9.0",
-    "grunt-shell": "^0.2.2",
-    "jasmine-focused": "^1.0.4",
-    "rimraf": "^2.2.2",
-    "temp": "^0.6.0"
+    "coffee-cache": "^0.5.0",
+    "coffeelint": "^1.15.7",
+    "coffee-script": "^1.10.0",
+    "grunt": "^0.4.5",
+    "grunt-atomdoc": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-coffeelint": "^0.0.16",
+    "grunt-contrib-coffee": "^1.0.0",
+    "grunt-shell": "^1.3.1",
+    "jasmine-focused": "^1.0.7",
+    "rimraf": "^2.5.4",
+    "temp": "^0.8.3"
   }
 }

--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -2,12 +2,21 @@ CompositeDisposable = require '../src/composite-disposable'
 Disposable = require '../src/disposable'
 
 describe "CompositeDisposable", ->
-  [disposable1, disposable2, disposable3] = []
+  [disposable1, disposable2, disposable3, destroyable1, destroyable2, destroyable3] = []
 
   beforeEach ->
     disposable1 = new Disposable
     disposable2 = new Disposable
     disposable3 = new Disposable
+    destroyable = class
+      constructor: ->
+        @disposed = false
+      destroy: ->
+        @disposed = true
+
+    destroyable1 = new destroyable()
+    destroyable2 = new destroyable()
+    destroyable3 = new destroyable()
 
   it "can be constructed with multiple disposables", ->
     composite = new CompositeDisposable(disposable1, disposable2)
@@ -16,6 +25,12 @@ describe "CompositeDisposable", ->
     expect(composite.disposed).toBe true
     expect(disposable1.disposed).toBe true
     expect(disposable2.disposed).toBe true
+
+  it "tolerates falsy things", ->
+    composite = new CompositeDisposable(null, null, undefined, undefined)
+    composite.dispose()
+
+    expect(composite.disposed).toBe true
 
   it "allows disposables to be added and removed", ->
     composite = new CompositeDisposable
@@ -29,3 +44,34 @@ describe "CompositeDisposable", ->
     expect(disposable1.disposed).toBe true
     expect(disposable2.disposed).toBe false
     expect(disposable3.disposed).toBe true
+
+  it "can be constructed with multiple destroyables", ->
+    composite = new CompositeDisposable(destroyable1, destroyable2)
+    composite.dispose()
+
+    expect(composite.disposed).toBe true
+    expect(destroyable1.disposed).toBe true
+    expect(destroyable2.disposed).toBe true
+
+  it "allows destroyables to be added and removed", ->
+    composite = new CompositeDisposable
+    composite.add(destroyable1)
+    composite.add(destroyable2, destroyable3)
+    composite.remove(destroyable2)
+
+    composite.dispose()
+
+    expect(composite.disposed).toBe true
+    expect(destroyable1.disposed).toBe true
+    expect(destroyable2.disposed).toBe false
+    expect(destroyable3.disposed).toBe true
+
+  it "can be constructed with destroyables and disposables", ->
+    composite = new CompositeDisposable(destroyable1, destroyable2, disposable1, disposable2)
+    composite.dispose()
+
+    expect(composite.disposed).toBe true
+    expect(destroyable1.disposed).toBe true
+    expect(destroyable2.disposed).toBe true
+    expect(disposable1.disposed).toBe true
+    expect(disposable2.disposed).toBe true

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -38,7 +38,8 @@ class CompositeDisposable
     unless @disposed
       @disposed = true
       @disposables.forEach (disposable) ->
-        disposable.dispose()
+        disposable?.dispose?()
+        disposable?.destroy?()
       @disposables = null
     return
 


### PR DESCRIPTION
This PR:

* Allows you to add objects with a `destroy()` function to CompositeDisposable
* Prevents errors if an item added to CompositeDisposable is falsy, or missing either a `dispose()` or `destroy()` function
* Updates `package.json` dependencies

If merged this should probably also close #28.