### PR TITLE
Add delete to CompositeDisposable

### DIFF
--- a/spec/composite-disposable-spec.coffee
+++ b/spec/composite-disposable-spec.coffee
@@ -21,14 +21,15 @@ describe "CompositeDisposable", ->
     composite = new CompositeDisposable
     composite.add(disposable1)
     composite.add(disposable2, disposable3)
-    composite.remove(disposable2)
+    composite.delete(disposable1)
+    composite.remove(disposable3)
 
     composite.dispose()
 
     expect(composite.disposed).toBe true
-    expect(disposable1.disposed).toBe true
-    expect(disposable2.disposed).toBe false
-    expect(disposable3.disposed).toBe true
+    expect(disposable1.disposed).toBe false
+    expect(disposable2.disposed).toBe true
+    expect(disposable3.disposed).toBe false
 
   describe "Adding non disposables", ->
     it "throws a TypeError when undefined", ->

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -69,7 +69,7 @@ class CompositeDisposable
     @disposables.delete(disposable) unless @disposed
     return
 
-  # Public: Alias to remove
+  # Public: Alias to {CompositeDisposable::remove}
   delete: (disposable) ->
     @remove(disposable)
     return

--- a/src/composite-disposable.coffee
+++ b/src/composite-disposable.coffee
@@ -69,6 +69,11 @@ class CompositeDisposable
     @disposables.delete(disposable) unless @disposed
     return
 
+  # Public: Alias to remove
+  delete: (disposable) ->
+    @remove(disposable)
+    return
+
   # Public: Clear all disposables. They will not be disposed by the next call
   # to dispose.
   clear: ->


### PR DESCRIPTION
Because `delete()` is available on both ES6 `Set` and `Map`, this adds a sense of predictability to `CompositeDisposable`. It's behavior is now more in line with the natives.
