### PR TITLE
Add MappedDisposable class

### DIFF
--- a/spec/mapped-disposable-spec.coffee
+++ b/spec/mapped-disposable-spec.coffee
@@ -1,0 +1,178 @@
+CompositeDisposable = require '../src/composite-disposable'
+Disposable = require '../src/disposable'
+MappedDisposable = require '../src/mapped-disposable'
+
+describe 'MappedDisposable', ->
+  it 'can be constructed with an iterable', ->
+    disposable1 = new Disposable
+    disposable2 = new Disposable
+    disposable3 = new CompositeDisposable
+    map = new MappedDisposable [
+      [{name: 'foo'}, disposable1]
+      [{name: 'bar'}, disposable2]
+      [{name: 'baz'}, disposable3]
+    ]
+    map.dispose()
+    expect(disposable1.disposed).toBe true
+    expect(disposable2.disposed).toBe true
+    expect(disposable3.disposed).toBe true
+
+  it 'can be constructed without an iterable', ->
+    map = new MappedDisposable
+    expect(map.disposed).toBe false
+    map.dispose()
+    expect(map.disposed).toBe true
+
+  it 'embeds ordinary disposables in CompositeDisposables', ->
+    disposable1 = new Disposable
+    disposable2 = new CompositeDisposable
+    map = new MappedDisposable [
+      ['foo', disposable1],
+      ['bar', disposable2]
+    ]
+    expect(map.get('foo')).toBeInstanceOf CompositeDisposable
+    expect(map.get('bar')).toBe disposable2
+
+  it 'allows disposables to be added to keys', ->
+    key = {}
+    cd1 = new CompositeDisposable
+    cd2 = new CompositeDisposable
+    cd3 = new CompositeDisposable
+    map = new MappedDisposable [[key, cd1]]
+    expect(map.get(key)).toBe cd1
+    map.add key, cd2
+    expect(cd1.disposables.size).toBe 1
+    map.add 'foo', cd3
+    expect(map.size).toBe 2
+    map.dispose()
+    expect(map.disposed).toBe true
+    expect(cd1.disposed).toBe true
+    expect(cd2.disposed).toBe true
+
+  it 'allows disposables to be used as keys', ->
+    calledIt = false
+    toldYou = false
+    disposableKey = new Disposable -> calledIt = true
+    disposableValue = new Disposable -> toldYou = true
+    map = new MappedDisposable [[disposableKey, disposableValue]]
+
+    expect(map.size).toBe 1
+    expect(calledIt).toBe false
+    expect(toldYou).toBe false
+    expect(disposableKey.disposed).toBe false
+    expect(disposableValue.disposed).toBe false
+
+    map.dispose()
+    expect(map.size).toBe 0
+    expect(disposableKey.disposed).toBe true
+    expect(disposableValue.disposed).toBe true
+    expect(calledIt).toBe true
+    expect(toldYou).toBe true
+
+  it "calls a key's dispose() method when disposing it", ->
+    foo = false
+    bar = false
+    fooDis = new Disposable -> foo = true
+    barDat = new Disposable -> bar = true
+    map = new MappedDisposable
+    map.set 'foo', fooDis
+    map.set 'bar', barDat
+
+    expect(map.size).toBe 2
+    expect(foo).toBe false
+    expect(bar).toBe false
+    expect(fooDis.disposed).toBe false
+    expect(barDat.disposed).toBe false
+
+    map.dispose 'foo'
+    expect(map.size).toBe 1
+    expect(foo).toBe true
+    expect(bar).toBe false
+    expect(fooDis.disposed).toBe true
+    expect(barDat.disposed).toBe false
+    expect(map.has('foo')).toBe false
+
+  it 'allows disposables to be removed from keys', ->
+    key = {}
+    cd1 = new CompositeDisposable
+    cd2 = new CompositeDisposable
+    cd3 = new CompositeDisposable
+    cd4 = new CompositeDisposable
+    cd5 = new CompositeDisposable
+    map = new MappedDisposable [[key, cd1]]
+    map.add key, cd2, cd3, cd4, cd5
+    expect(cd1.disposables.size).toBe 4
+    map.remove key, cd3, cd5
+    expect(cd1.disposables.size).toBe 2
+    map.dispose()
+    expect(map.disposed).toBe true
+    expect(cd1.disposed).toBe true
+    expect(cd2.disposed).toBe true
+    expect(cd3.disposed).toBe false
+    expect(cd4.disposed).toBe true
+    expect(cd5.disposed).toBe false
+
+  it 'allows other MappedDisposables to be added to keys', ->
+    disposable = new Disposable
+    map1 = new MappedDisposable [['foo', disposable]]
+    map2 = new MappedDisposable [['bar', map1]]
+    expect(map1.get('foo').disposables.has(disposable)).toBe true
+    expect(map2.get('bar').disposables.has(map1)).toBe true
+    map2.dispose()
+    expect(disposable.disposed).toBe true
+    expect(map1.disposed).toBe true
+    expect(map2.disposed).toBe true
+  
+  it 'reports accurate entry count', ->
+    map = new MappedDisposable
+    expect(map.size).toBe 0
+    map.add 'foo', new Disposable
+    expect(map.size).toBe 1
+    map.add 'foo', new Disposable
+    map.add 'bar', new Disposable
+    expect(map.size).toBe 2
+    map.delete 'foo'
+    expect(map.size).toBe 1
+    map.dispose()
+    expect(map.size).toBe 0
+  
+  it 'deletes keys when disposing them', ->
+    key = {}
+    cd1 = new CompositeDisposable
+    map = new MappedDisposable [[key, cd1]]
+    map.delete key
+    expect(map.has(key)).toBe false
+    expect(map.get(key)).toBe undefined
+    map.dispose()
+    expect(cd1.disposed).toBe false
+  
+  it 'deletes all keys when disposed', ->
+    map = new MappedDisposable [
+      ['foo', new Disposable]
+      ['bar', new Disposable]
+    ]
+    expect(map.has('foo')).toBe true
+    expect(map.has('bar')).toBe true
+    map.dispose()
+    expect(map.has('foo')).toBe false
+    expect(map.has('bar')).toBe false
+    expect(map.size).toBe 0
+
+  it 'allows a disposable list to be replaced with another', ->
+    cd1 = new CompositeDisposable
+    cd2 = new CompositeDisposable
+    key = {}
+    map = new MappedDisposable [[key, cd1]]
+    map.set key, cd2
+    expect(map.get(key)).toBe cd2
+    expect(map.get(key).disposables.has(cd1)).toBe false
+    map.dispose()
+    expect(cd1.disposed).toBe false
+    expect(cd2.disposed).toBe true
+
+  it 'throws an error when setting a value to a non-disposable', ->
+    fn = ->
+      key = {}
+      map = new MappedDisposable [[key, new Disposable]]
+      map.set key, {}
+    expect(fn).toThrow()

--- a/spec/mapped-disposable-spec.coffee
+++ b/spec/mapped-disposable-spec.coffee
@@ -30,7 +30,7 @@ describe 'MappedDisposable', ->
       ['foo', disposable1],
       ['bar', disposable2]
     ]
-    expect(map.get('foo')).toBeInstanceOf CompositeDisposable
+    expect(map.get('foo') instanceof CompositeDisposable).toBe true
     expect(map.get('bar')).toBe disposable2
 
   it 'allows disposables to be added to keys', ->

--- a/src/mapped-disposable.coffee
+++ b/src/mapped-disposable.coffee
@@ -1,0 +1,146 @@
+[CompositeDisposable, Disposable] = []
+
+# Essential: Map-based equivalent of a {CompositeDisposable}.
+#
+# Helpful alternative to managing several CompositeDisposable
+# instances, which can be referenced or disposed from the same
+# object.
+#
+# ## Examples
+#
+# ```coffee
+# {MappedDisposable} = require 'atom'
+#
+# class Something
+#   constructor: ->
+#     @disposables = new MappedDisposable
+#     editor = atom.workspace.getActiveTextEditor()
+#     @disposables.set "editor-changed", editor.onDidChange ->
+#     @disposables.set "path-changed", editor.onDidChangePath ->
+#
+#     # CompositeDisposables work well with objects as keys:
+#     onChangeText = editor.onDidChange ->
+#     onChangePath = editor.onDidChangePath ->
+#     @disposables.set editor, new CompositeDisposable(onChangeText, onChangePath)
+#     @disposables.add editor, editor.onDidDestroy ->
+#       @disposables.dispose editor
+#
+#   destroy: ->
+#     @disposables.dispose()
+# ```
+module.exports =
+class MappedDisposable
+  disposed: false
+
+  ###
+  Section: Construction and Destruction
+  ###
+
+  # Public: Create a new instance, optionally with a list of keys and disposables.
+  constructor: (iterable) ->
+    @disposables = new Map()
+    CompositeDisposable ?= require './composite-disposable'
+    if iterable?
+      for entry in iterable
+        [key, value] = entry
+        unless value instanceof CompositeDisposable
+          value = new CompositeDisposable value
+        @disposables.set key, value
+
+  # Public: Delete keys and dispose of their values.
+  #
+  # * `...keys` Keys to dispose of. If none are passed, the method disposes of
+  #             everything, rendering the instance completely inert.
+  dispose: ->
+    return if @disposed
+    if arguments.length
+      for key in arguments by 1
+        disposable = @disposables.get key
+        if typeof key?.dispose is 'function'
+          key.dispose()
+        if disposable
+          disposable.dispose()
+          @disposables.delete key
+    else
+      @disposed = true
+      @disposables.forEach (value, key) ->
+        value.dispose()
+        if typeof key?.dispose is 'function'
+          key.dispose()
+      @disposables.clear()
+      @disposables = null
+    return
+
+
+  ###
+  Section: Managing Disposables
+  ###
+
+  # Public: Key one or more {Disposable} instances to an object.
+  #
+  # * `key`
+  # * `...disposables`
+  add: (key, disposables...) ->
+    return if @disposed
+    if keyDisposables = @disposables.get(key)
+      for disposable in disposables
+        keyDisposables.add(disposable)
+    else
+      @disposables.set key, new CompositeDisposable(disposables...)
+    return
+
+  # Public: Remove a {Disposable} from an object's disposables list.
+  #
+  # If no disposables are passed, the object itself is removed from the
+  # MappedDisposable. Any disposables keyed to it are not disposed of.
+  #
+  # * `key`
+  # * `...disposables`
+  remove: (key, disposables...) ->
+    return if @disposed
+
+    if disposable = @disposables.get key
+      # Remove specific disposables if any were provided
+      if disposables.length
+        for unwantedDisposable in disposables
+          disposable.remove unwantedDisposable
+
+      # Otherwise, remove the keyed object itself
+      else @disposables.delete key
+
+    return
+
+  # Public: Alias of {MappedDisposable::remove}, included for parity with Map objects.
+  delete: (key, disposables...) ->
+    @remove(key, disposables...)
+
+  # Public: Clear the MappedDisposable's contents. Disposables keyed to objects are not disposed of.
+  clear: ->
+    @disposables.clear() unless @disposed
+
+  # Public: Number of entries (key/disposable pairs) stored in the instance.
+  Object.defineProperty @::, 'size',
+    get: -> if @disposed then 0 else @disposables.size
+
+  # Public: Determine if an entry with the given key exists in the MappedDisposable.
+  has: (key) ->
+    return false if @disposed
+    @disposables.has key
+
+  # Public: Retrieve the disposables list keyed to an object.
+  #
+  # Returns a {CompositeDisposable} instance, or `undefined` if
+  # the MappedDisposable has been disposed of.
+  get: (key) ->
+    return if @disposed
+    @disposables.get key
+
+  # Public: Replace the {Disposable} keyed to an object.
+  #
+  # Throws a TypeError if the object lacks a `dispose` method.
+  set: (key, value) ->
+    return if @disposed
+    Disposable ?= require './disposable'
+    unless Disposable.isDisposable value
+      throw new TypeError('Value must have a .dispose() method')
+    @disposables.set key, value


### PR DESCRIPTION
I wrote this class for [File Icons v2](https://github.com/file-icons/atom/blob/cb71ea6370d5cfb6e58c4645b101a84921f2b8c1/lib/utils/mapped-disposable.js), which makes very extensive use of Maps and Sets. `MappedDisposables` follow the same principle as `CompositeDisposables`, but they're much more flexible in their application. Observe:

~~~js
class Before{
	constructor(editor){
		this.editorDisposables = new CompositeDisposable(
			editor.onDidSave(() => …),
			editor.onDidDestroy(() => …),
			editor.onDidChangeTitle(() => …)
		);
		
		this.projectDisposables = new CompositeDisposable(
			atom.project.onDidAddBuffer(() => …),
			atom.project.onDidChangePaths(() => …)
		);
		
		this.paneDisposable = atom.workspace.onDidAddPane(() => …);
		this.commandDisposables = atom.commands.add(…);
	}
}
~~~

The above code can be simplified using a `MappedDisposable`, without sacrificing any existing functionality:

~~~js
class After{
	constructor(editor){
		this.disposables = new MappedDisposable();
		this.disposables.add(editor,
			editor.onDidSave(() => …),
			editor.onDidDestroy(() => …),
			editor.onDidChangeTitle(() => …)
		);
		this.disposables.add("project", atom.project.onDidAddBuffer(() => …));
		this.disposables.add("project", atom.project.onDidChangePaths(() => …));
		this.disposables.add("pane", atom.workspace.onDidAddPane(() => …));
		this.disposables.add("commands", atom.commands.add(…));
		
		this.disposables.delete("commands"); // Delete but don't dispose command disposable
		this.disposables.dispose("pane");    // Dispose and delete onDidAddPane handler
		this.disposables.dispose();          // Dispose of everything
	}
}
~~~

As you can see, the class is quite forgiving with how it accepts new `Disposables`. Internally, everything is enclosed inside a `CompositeDisposable`, irrespective of what type of "disposable" an argument is (provided it defines a `dispose()` method).

Because keys are checked for `dispose()` methods as well as their values, a `MappedDisposable` can be used as a drop-in replacement for a regular `CompositeDisposable`, even if the author doesn't give a damn about identifying disposables:

~~~js
this.disposables = new MappedDisposable();

// Implicitly maps following `onDidDestroy` and `onDidChangeTitle`
// handlers to first argument (the `editor.onDidSave` handler).
this.disposables.add(
	editor.onDidSave(() => …),
	editor.onDidDestroy(() => …),
	editor.onDidChangeTitle(() => …)
);

// Nukes onDidSave handler as well as everything else
this.disposables.dispose();
~~~

It's amazing how well this works.

**NOTE:** If parts of the class don't taste like coffee, that's because they were ported from JavaScript. Apologies.