### PR TITLE
Add `once()` method to Emitter

### DIFF
--- a/spec/emitter-spec.coffee
+++ b/spec/emitter-spec.coffee
@@ -80,6 +80,22 @@ describe "Emitter", ->
     emitter.clear()
     expect(emitter.getTotalListenerCount()).toBe(0)
 
+  describe "::once", ->
+    it "only invokes the handler once", ->
+      emitter = new Emitter
+      firedCount = 0
+      emitter.once 'foo', -> firedCount += 1
+      emitter.emit 'foo'
+      emitter.emit 'foo'
+      expect(firedCount).toBe 1
+
+    it "invokes the handler with the emitted value", ->
+      emitter = new Emitter
+      emittedValue = null
+      emitter.once 'foo', (value) -> emittedValue = value
+      emitter.emit 'foo', 'bar'
+      expect(emittedValue).toBe 'bar'
+
   describe "when a handler throws an exception", ->
     describe "when no exception handlers are registered on Emitter", ->
       it "throws exceptions as normal, stopping subsequent handlers from firing", ->

--- a/src/emitter.coffee
+++ b/src/emitter.coffee
@@ -101,6 +101,21 @@ class Emitter
 
     new Disposable(@off.bind(this, eventName, handler))
 
+  # Public: Register the given handler function to be invoked the next time an
+  # events with the given name is emitted via {::emit}.
+  #
+  # * `eventName` {String} naming the event that you want to invoke the handler
+  #   when emitted.
+  # * `handler` {Function} to invoke when {::emit} is called with the given
+  #   event name.
+  #
+  # Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  once: (eventName, handler, unshift=false) ->
+    wrapped = (value) ->
+      disposable.dispose()
+      handler(value)
+    disposable = @on(eventName, wrapped, unshift)
+
   # Public: Register the given handler function to be invoked *before* all
   # other handlers existing at the time of subscription whenever events by the
   # given name are emitted via {::emit}.


### PR DESCRIPTION
Like the method on node's EventEmitter, this allows you to register a one-time listener.

cc @nathansobo @maxbrunsfeld @BinaryMuse