### PR TITLE
Add emitAsync method

### DIFF
--- a/src/emitter.coffee
+++ b/src/emitter.coffee
@@ -165,6 +165,13 @@ class Emitter
         @constructor.dispatch(handler, value)
     return
 
+  emitAsync: (eventName, value) ->
+    if handlers = @handlersByEventName?[eventName]
+      promises = for handler in handlers
+        @constructor.dispatch(handler, value)
+      return Promise.all(promises).then -> return
+    return Promise.resolve()
+
   getEventNames: ->
     Object.keys(@handlersByEventName)
 


### PR DESCRIPTION
This adds a new method to the `Emitter` class: `emitAsync`. The method behaves like `emit` except that if any handlers return promises, `emitAsync` will aggregate those promises via `Promise.all`, so that applications can wait until events have been handled asynchronously. I plan to use this in Atom's `Workspace.onWillDestroyPaneItem` and `TextBuffer.onWillSave` methods.

/cc @nathansobo 
/cc @joefitzgerald since I know you were interested in this feature at one time.