### PR TITLE
Track active subscriptions and clean up when emitter is disposed

### DIFF
--- a/spec/emitter-spec.coffee
+++ b/spec/emitter-spec.coffee
@@ -96,6 +96,22 @@ describe "Emitter", ->
       emitter.emit 'foo', 'bar'
       expect(emittedValue).toBe 'bar'
 
+  describe "dispose", ->
+    it "disposes of all listeners", ->
+      emitter = new Emitter
+      disposable1 = emitter.on 'foo', ->
+      disposable2 = emitter.once 'foo', ->
+      emitter.dispose()
+      expect(disposable1.disposed).toBe true
+      expect(disposable2.disposed).toBe true
+
+    it "doesn't keep track of disposed disposables", ->
+      emitter = new Emitter
+      disposable = emitter.on 'foo', ->
+      expect(emitter.subscriptions.disposables.size).toBe 1
+      disposable.dispose()
+      expect(emitter.subscriptions.disposables.size).toBe 0
+
   describe "when a handler throws an exception", ->
     describe "when no exception handlers are registered on Emitter", ->
       it "throws exceptions as normal, stopping subsequent handlers from firing", ->


### PR DESCRIPTION
While tracking memory leaks in Nuclide/Atom, @hansonw realized that things listening to editor events could easily fail to do cleanup on destruction, therefore inadvertently maintaining references to editors (via the closed over `@off.bind(this, eventName, handler)`). Furthermore, cleanup isn't exactly straightforward because you also need to remember to clean up the `onDidDestroy()` listener you added to clean up the first one.

This solves the issue at the root: if you dispose of an event emitter, all of its handlers will be torn down.