### PR TITLE
Mutate listener lists when (un)subscribing and emit over a copy

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -120,9 +120,9 @@ class Emitter {
     const currentHandlers = this.handlersByEventName[eventName]
     if (currentHandlers) {
       if (unshift) {
-        this.handlersByEventName[eventName] = [handler].concat(currentHandlers)
+        this.handlersByEventName[eventName].unshift(handler)
       } else {
-        this.handlersByEventName[eventName] = currentHandlers.concat(handler)
+        this.handlersByEventName[eventName].push(handler)
       }
     } else {
       this.handlersByEventName[eventName] = [handler]
@@ -190,17 +190,13 @@ class Emitter {
       return
     }
 
-    const oldHandlers = this.handlersByEventName[eventName]
-    if (oldHandlers) {
-      const newHandlers = []
-      for (let handler of oldHandlers) {
-        if (handler !== handlerToRemove) {
-          newHandlers.push(handler)
-        }
+    const handlers = this.handlersByEventName[eventName]
+    if (handlers) {
+      const handlerIndex = handlers.indexOf(handlerToRemove)
+      if (handlerIndex >= 0) {
+        handlers.splice(handlerIndex, 1)
       }
-      if (newHandlers.length > 0) {
-        this.handlersByEventName[eventName] = newHandlers
-      } else {
+      if (handlers.length === 0) {
         delete this.handlersByEventName[eventName]
       }
     }
@@ -219,8 +215,12 @@ class Emitter {
     const handlers =
       this.handlersByEventName && this.handlersByEventName[eventName]
     if (handlers) {
-      for (let handler of handlers) {
-        this.constructor.dispatch(handler, value)
+      // create a copy of `handlers` so that if any handler mutates `handlers`
+      // (e.g. by calling `on` on this same emitter), this does not result in
+      // changing the handlers being called during this same `emit`.
+      const handlersCopy = handlers.slice()
+      for (let i = 0; i < handlersCopy.length; i++) {
+        this.constructor.dispatch(handlersCopy[i], value)
       }
     }
   }

--- a/spec/emitter-spec.js
+++ b/spec/emitter-spec.js
@@ -40,6 +40,18 @@ describe("Emitter", function() {
     expect(() => emitter.on("foo", "a")).toThrow()
   })
 
+  it("can register a function more than once, and therefore will call it multiple times", function() {
+    const emitter = new Emitter();
+    let callCount = 0;
+    const fn = () => callCount++
+
+    emitter.on('foo', fn);
+    emitter.on('foo', fn);
+    emitter.emit('foo')
+
+    expect(callCount).toEqual(2);
+  })
+
   it("allows all subsribers to be cleared out at once", function() {
     const emitter = new Emitter()
     const events = []


### PR DESCRIPTION
This allows for O(1) subscriptions in the common (non-prepend) case and O(n) unsubscriptions by simply mutating the set when adding or removing a 

Instead, iterate over a copy of the listeners during the emit phase.

**Test Plan**: `npm test` as well as linking this module into Atom, and smoke testing Atom and Nuclide.