### PR TITLE
Change licenses to license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/atom/event-kit/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/atom/event-kit/raw/master/LICENSE.md"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.1",


### PR DESCRIPTION
I noticed that in npm's [`package.json` documentation](https://docs.npmjs.com/files/package.json#license), the `licenses` key is no longer valid:

![image](https://user-images.githubusercontent.com/2344137/45510862-4c4a3b00-b750-11e8-9f3d-57faa4f03ead.png)

The npm page for [event-kit](https://www.npmjs.com/package/event-kit) currently reports that this package does not have a license:

![image](https://user-images.githubusercontent.com/2344137/45510889-66841900-b750-11e8-95d5-5a0565420331.png)

This PR changes the `licenses` key to `license` in order for npm to properly show the package's license as MIT.