### PR TITLE
Update devDependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 spec
 script
 src
-lib
 .npmignore
 .DS_Store
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ notifications:
     on_failure: change
 
 node_js:
-  - 8
+  - 10
+  - 12
+  - 14
 
 git:
   depth: 10

--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ const {Disposable} = require('event-kit')
 
 const disposable = new Disposable(() => this.destroyResource())
 ```
+
+### Using ES6 Code
+You can use the ES6 style classes from `lib` directory.
+```
+const {Disposable} = require('event-kit/lib/event-kit')
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,15 @@
 environment:
-  nodejs_version: "6"
+  matrix:
+    - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "14"
 
 platform:
   - x64
   - x86
 
 install:
+  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version
   - npm install
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+let presets = ["babel-preset-atomic"];
+
+let plugins = ["@babel/plugin-transform-classes"] // this is needed so Disposabale can be extended by ES5-style classes
+
+module.exports = {
+  presets: presets,
+  plugins: plugins,
+  exclude: "node_modules/**",
+  sourceMap: true,
+}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "babel-preset-atomic": "^2.5.4",
     "cross-env": "^7.0.2",
     "jasmine-focused": "^1.0.7",
-    "joanna": "https://github.com/aminya/joanna",
-    "rimraf": "^2.2.2",
-    "temp": "^0.6.0"
+    "joanna": "https://github.com/aminya/joanna"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",
-    "@babel/preset-env": "^7.1.0",
+    "babel-preset-atomic": "^2.5.4",
+    "cross-env": "^7.0.2",
     "jasmine-focused": "^1.0.4",
     "joanna": "0.0.11",
     "rimraf": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Simple library for implementing and consuming evented APIs",
   "main": "./dist/event-kit",
   "scripts": {
-    "prepublish": "babel lib --out-dir dist --presets @babel/env && joanna-tello -o api.json package.json lib",
+    "build": "cross-env BABEL_KEEP_MODULES=false babel lib --out-dir dist --delete-dir-on-start",
+    "docs": "joanna-tello -o api.json package.json lib",
+    "prepublish": "npm run build && npm run docs",
     "test": "jasmine-focused --captureExceptions --forceexit spec"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-atomic": "^2.5.4",
     "cross-env": "^7.0.2",
     "jasmine-focused": "^1.0.4",
-    "joanna": "0.0.11",
+    "joanna": "https://github.com/aminya/joanna",
     "rimraf": "^2.2.2",
     "temp": "^0.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.12.3",
     "babel-preset-atomic": "^2.5.4",
     "cross-env": "^7.0.2",
-    "jasmine-focused": "^1.0.4",
+    "jasmine-focused": "^1.0.7",
     "joanna": "https://github.com/aminya/joanna",
     "rimraf": "^2.2.2",
     "temp": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.12.1",
-    "@babel/core": "^7.12.3",
-    "babel-preset-atomic": "^2.5.4",
-    "cross-env": "^7.0.2",
+    "@babel/cli": "^7.12.10",
+    "@babel/core": "^7.12.10",
+    "babel-preset-atomic": "^3.0.1",
+    "cross-env": "^7.0.3",
     "jasmine-focused": "^1.0.7",
     "joanna": "https://github.com/aminya/joanna"
   }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@babel/cli": "^7.1.2",
-    "@babel/core": "^7.1.2",
+    "@babel/cli": "^7.12.1",
+    "@babel/core": "^7.12.3",
     "babel-preset-atomic": "^2.5.4",
     "cross-env": "^7.0.2",
     "jasmine-focused": "^1.0.4",


### PR DESCRIPTION
### Description of the change

- This PR updates the devDependencies of event-kit. 
- It uses babel-preset-atomic as the babel preset.
- Allows the non-transformed code to be included in the npm package (lib folder).

It uses my joanna fork which supports parsing new JavaScript. If you merge that PR, we can use the package itself. https://github.com/atom/joanna/pull/12. 

### Benefits
- By using non-transformed code, users can use ES6 classes.  This is useful since babel transformation converts the ES6 classes to prototypical functions. By including the lib folder, the users can opt into using the ES6 class code by requiring the `event-kit/lib/event-kit`

- Allows us to modernize event-kit code in the future PRs (see #52)

### Verification 
All the tests pass:
![image](https://user-images.githubusercontent.com/16418197/97063539-ef8ff000-1565-11eb-86cf-6f63e016ce7a.png)


